### PR TITLE
Shortcut for map form and field_name attrs

### DIFF
--- a/lib/phoenix_components/view.ex
+++ b/lib/phoenix_components/view.ex
@@ -105,6 +105,18 @@ defmodule PhoenixComponents.View do
   def component(namespace, name, attrs, do: block) when is_list(attrs) do
     do_component(namespace, name, block, attrs)
   end
+  
+  def component(namespace, name, %Phoenix.HTML.Form{} = form, field) when is_atom(field) do
+    do_component(namespace, name, "", [form: form, field: field])
+  end
+
+  def component(namespace, name, %Phoenix.HTML.Form{} = form, field, attrs) when is_list(attrs) and is_atom(field) do
+    do_component(namespace, name, "", Keyword.merge(attrs, [form: form, field: field]))
+  end
+
+  def component(namespace, name, %Phoenix.HTML.Form{} = form, field, attrs, do: block) when is_list(attrs) and is_atom(field) do
+    do_component(namespace, name, block, Keyword.merge(attrs, [form: form, field: field]))
+  end
 
   defp do_component(namespace, name, content, attrs) do
     safe_content = html_escape(content)


### PR DESCRIPTION
Added the option to use a custom component, when in a form, in a similar way as of the Phoenix html inputs. 
This options will map the form object(first arg) to the @attr :form and the field_name(second arg) to @attr :field_name automatically, therefore making the code more clear as developers can avoid unnecessary mappings.
Example: 
* Before
= currency_select form: f, field: :currency_iso

* After
= currency_select f, :currency_iso

* Comparing to Phoenix HTML input:
= text_input f, :description

* Custom component implementation:
= select @attrs.form, @attrs.field, currencies(), class: "form-control"